### PR TITLE
Swap the locations of catering and baggage/external power on the ground page of the EFB

### DIFF
--- a/src-a339/instruments/src/EFB/Ground/Ground.tsx
+++ b/src-a339/instruments/src/EFB/Ground/Ground.tsx
@@ -216,6 +216,30 @@ export const Ground = ({
 
             <div className="right-72 grid grid-cols-2 control-grid absolute top-16">
                 <div>
+                    <h1 className="text-white font-medium text-xl text-center pb-1">Door Aft</h1>
+                    <DoorToggle
+                        tugActive={tugActive}
+                        index={3}
+                        onClick={handleClick}
+                        selectionCallback={applySelectedWithSync}
+                        id="door-fwd-right"
+                        disabled={disabledButtons.includes('door-fwd-right')}
+                    />
+                </div>
+                <div>
+                    <h1 className="text-white font-medium text-xl text-center pb-1">Catering</h1>
+                    <Button
+                        onClick={(e) => handleClick(() => setCateringActive(1), e, 'door-fwd-right')}
+                        className={applySelectedWithSync('w-32', 'catering', cateringActive, 'door-fwd-right')}
+                        type={BUTTON_TYPE.NONE}
+                        id="catering"
+                    >
+                        <IconArchive size="2.825rem" stroke="1.5" />
+                    </Button>
+                </div>
+            </div>
+            <div className="right-72 grid grid-cols-2 control-grid absolute bottom-36">
+            <div>
                     <h1 className="text-white font-medium text-xl text-center pb-1">Baggage</h1>
                     <Button
                         onClick={(e) => handleClick(() => setCargoActive(1), e)}
@@ -235,30 +259,6 @@ export const Ground = ({
                         id="power"
                     >
                         <IconPlug size="2.825rem" stroke="1.5" />
-                    </Button>
-                </div>
-            </div>
-            <div className="right-72 grid grid-cols-2 control-grid absolute bottom-36">
-                <div>
-                    <h1 className="text-white font-medium text-xl text-center pb-1">Door Aft</h1>
-                    <DoorToggle
-                        tugActive={tugActive}
-                        index={3}
-                        onClick={handleClick}
-                        selectionCallback={applySelectedWithSync}
-                        id="door-aft-right"
-                        disabled={disabledButtons.includes('door-aft-right')}
-                    />
-                </div>
-                <div>
-                    <h1 className="text-white font-medium text-xl text-center pb-1">Catering</h1>
-                    <Button
-                        onClick={(e) => handleClick(() => setCateringActive(1), e, 'door-aft-right')}
-                        className={applySelectedWithSync('w-32', 'catering', cateringActive, 'door-aft-right')}
-                        type={BUTTON_TYPE.NONE}
-                        id="catering"
-                    >
-                        <IconArchive size="2.825rem" stroke="1.5" />
                     </Button>
                 </div>
             </div>


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Catering uses the forward right door in-game, but the EFB previously had catering at the back, and labelled the door used as right aft. This commit swaps the icons so the actual location is accurately reflected in the EFB.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before
![image](https://user-images.githubusercontent.com/66269211/181108450-95d0bed0-63f2-4a5a-a4df-26cd13fa80e5.png)
After
![image](https://user-images.githubusercontent.com/66269211/181108317-5aeaa3e3-a484-4ee0-bdcc-15fd458acf7b.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->
![image](https://user-images.githubusercontent.com/66269211/181108824-5f26ddc5-8c35-4d9f-a36d-634da2c68492.png)

## Additional context
<!-- Add any other context about the pull request here. -->
This will be broken by FlyPadOS3, but a very similar change can be made to replicate this change on FlyPadOS3

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Genau#1366

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Ensure that the catering truck uses the right forward door
- Ensure that the catering on the EFB is next to the forward door

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page