### PR TITLE
fix: use included light effects instead of A32NX effects

### DIFF
--- a/hdw-a339x/src/base/headwindsim-aircraft-a330-900/SimObjects/Airplanes/Headwind_A330neo/systems.cfg
+++ b/hdw-a339x/src/base/headwindsim-aircraft-a330-900/SimObjects/Airplanes/Headwind_A330neo/systems.cfg
@@ -161,109 +161,109 @@ lightdef.79 = Type:7#Index:1#LocalPosition:28.23,0.242,-4.501#LocalRotation:2,0,
 ; INTERIOR LIGHTING
 
 ; OVHD INTEG LT AMBIENT (DONE)
-lightdef.80 = Type:4#Index:8#LocalPosition:67.03,0,5.535#LocalRotation:-75,0,0#EffectFile:LIGHT_A32NX_EmissiveAmbientL#PotentiometerIndex:86        ; OVHD AMB L LOW
-lightdef.81 = Type:4#Index:8#LocalPosition:67.03,-2,7.235#LocalRotation:0,0,-90#EffectFile:LIGHT_A32NX_EmissiveAccent#PotentiometerIndex:86         ; OVHD ACC LOW L
-lightdef.82 = Type:4#Index:8#LocalPosition:67.93,2,6.935#LocalRotation:0,0,90#EffectFile:LIGHT_A32NX_EmissiveAccent#PotentiometerIndex:86           ; OVHD ACC LOW R
-lightdef.83 = Type:4#Index:8#LocalPosition:68.23,-0.42,6.745#LocalRotation:112,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:86    ; OVHD AMB M LOW
-lightdef.84 = Type:4#Index:8#LocalPosition:68.23,0.375,6.745#LocalRotation:112,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:86    ; OVHD AMB M LOW
-lightdef.85 = Type:4#Index:8#LocalPosition:67.53,-1.05,6.995#LocalRotation:112,0,7#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:86        ; OVHD AMB M LOW
-lightdef.86 = Type:4#Index:8#LocalPosition:65.03,0,6.635#LocalRotation:-70,0,0#EffectFile:LIGHT_A32NX_EmissiveAmbientL#PotentiometerIndex:86        ; OVHD AMB L UPP
-lightdef.87 = Type:4#Index:8#LocalPosition:64.03,0,8.635#LocalRotation:45,0,0#EffectFile:LIGHT_A32NX_EmissiveAccent#PotentiometerIndex:86           ; OVHD ACC UPP
+lightdef.80 = Type:4#Index:8#LocalPosition:67.03,0,5.535#LocalRotation:-75,0,0#EffectFile:LIGHT_A339_EmissiveAmbientL#PotentiometerIndex:86        ; OVHD AMB L LOW
+lightdef.81 = Type:4#Index:8#LocalPosition:67.03,-2,7.235#LocalRotation:0,0,-90#EffectFile:LIGHT_A339_EmissiveAccent#PotentiometerIndex:86         ; OVHD ACC LOW L
+lightdef.82 = Type:4#Index:8#LocalPosition:67.93,2,6.935#LocalRotation:0,0,90#EffectFile:LIGHT_A339_EmissiveAccent#PotentiometerIndex:86           ; OVHD ACC LOW R
+lightdef.83 = Type:4#Index:8#LocalPosition:68.23,-0.42,6.745#LocalRotation:112,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:86    ; OVHD AMB M LOW
+lightdef.84 = Type:4#Index:8#LocalPosition:68.23,0.375,6.745#LocalRotation:112,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:86    ; OVHD AMB M LOW
+lightdef.85 = Type:4#Index:8#LocalPosition:67.53,-1.05,6.995#LocalRotation:112,0,7#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:86        ; OVHD AMB M LOW
+lightdef.86 = Type:4#Index:8#LocalPosition:65.03,0,6.635#LocalRotation:-70,0,0#EffectFile:LIGHT_A339_EmissiveAmbientL#PotentiometerIndex:86        ; OVHD AMB L UPP
+lightdef.87 = Type:4#Index:8#LocalPosition:64.03,0,8.635#LocalRotation:45,0,0#EffectFile:LIGHT_A339_EmissiveAccent#PotentiometerIndex:86           ; OVHD ACC UPP
 
 ; FCU INTEG LT AMBIENT (DONE)
-lightdef.88 = Type:12#Index:5#LocalPosition:69.543,-0.2,5.18#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:84    ; FCU AMB M L
-lightdef.89 = Type:12#Index:5#LocalPosition:69.543,-0.985,5.154#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:84     ; FCU AMB M L
-lightdef.90 = Type:12#Index:5#LocalPosition:69.543,0.2,5.18#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:84     ; FCU AMB M R
-lightdef.91 = Type:12#Index:5#LocalPosition:69.543,0.95,5.135#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:84      ; FCU AMB M R
-lightdef.92 = Type:12#Index:5#LocalPosition:69.53,-0.42,5.115#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:84      ; FCU AMB M MID L
-lightdef.93 = Type:12#Index:5#LocalPosition:69.535,0,5.128#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:84        ; FCU AMB M MID
-lightdef.94 = Type:12#Index:5#LocalPosition:69.53,0.42,5.115#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:84        ; FCU AMB M MID R
-lightdef.95 = Type:12#Index:5#LocalPosition:69.54,-0.25,5.165#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveS#PotentiometerIndex:84      ; FCU AMB S L
-lightdef.96 = Type:12#Index:5#LocalPosition:69.03,-0.67,5.085#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_EmissiveAmbientS#PotentiometerIndex:84     ; FCU AMB S L
-lightdef.97 = Type:12#Index:5#LocalPosition:69.03,-0.21,5.085#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_EmissiveAmbientS#PotentiometerIndex:84     ; FCU AMB S L
-lightdef.98 = Type:12#Index:5#LocalPosition:69.54,0.26,5.165#LocalRotation:-167,0,0#EffectFile:LIGHT_A32NX_EmissiveS#PotentiometerIndex:84       ; FCU AMB S R
-lightdef.99 = Type:12#Index:5#LocalPosition:69.015,0.34,5.085#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_EmissiveAmbientS#PotentiometerIndex:84  ; FCU AMB S R
-lightdef.100 = Type:12#Index:5#LocalPosition:69.03,0.67,5.085#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_EmissiveAmbientS#PotentiometerIndex:84      ; FCU AMB S R
+lightdef.88 = Type:12#Index:5#LocalPosition:69.543,-0.2,5.18#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:84    ; FCU AMB M L
+lightdef.89 = Type:12#Index:5#LocalPosition:69.543,-0.985,5.154#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:84     ; FCU AMB M L
+lightdef.90 = Type:12#Index:5#LocalPosition:69.543,0.2,5.18#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:84     ; FCU AMB M R
+lightdef.91 = Type:12#Index:5#LocalPosition:69.543,0.95,5.135#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:84      ; FCU AMB M R
+lightdef.92 = Type:12#Index:5#LocalPosition:69.53,-0.42,5.115#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:84      ; FCU AMB M MID L
+lightdef.93 = Type:12#Index:5#LocalPosition:69.535,0,5.128#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:84        ; FCU AMB M MID
+lightdef.94 = Type:12#Index:5#LocalPosition:69.53,0.42,5.115#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:84        ; FCU AMB M MID R
+lightdef.95 = Type:12#Index:5#LocalPosition:69.54,-0.25,5.165#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveS#PotentiometerIndex:84      ; FCU AMB S L
+lightdef.96 = Type:12#Index:5#LocalPosition:69.03,-0.67,5.085#LocalRotation:0,0,0#EffectFile:LIGHT_A339_EmissiveAmbientS#PotentiometerIndex:84     ; FCU AMB S L
+lightdef.97 = Type:12#Index:5#LocalPosition:69.03,-0.21,5.085#LocalRotation:0,0,0#EffectFile:LIGHT_A339_EmissiveAmbientS#PotentiometerIndex:84     ; FCU AMB S L
+lightdef.98 = Type:12#Index:5#LocalPosition:69.54,0.26,5.165#LocalRotation:-167,0,0#EffectFile:LIGHT_A339_EmissiveS#PotentiometerIndex:84       ; FCU AMB S R
+lightdef.99 = Type:12#Index:5#LocalPosition:69.015,0.34,5.085#LocalRotation:0,0,0#EffectFile:LIGHT_A339_EmissiveAmbientS#PotentiometerIndex:84  ; FCU AMB S R
+lightdef.100 = Type:12#Index:5#LocalPosition:69.03,0.67,5.085#LocalRotation:0,0,0#EffectFile:LIGHT_A339_EmissiveAmbientS#PotentiometerIndex:84      ; FCU AMB S R
 
 ; MAIN PNL INTEG LT AMBIENT (DONE)
-lightdef.101 = Type:4#Index:7#LocalPosition:69.25,-2.955,4.505#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85     ; MAIN PNL AMB M L
-lightdef.102 = Type:4#Index:7#LocalPosition:69.27,-2.825,4.685#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85      ; MAIN PNL AMB M L
-lightdef.103 = Type:4#Index:7#LocalPosition:70.052,-2.41,4.505#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85      ; MAIN PNL AMB M L
-lightdef.104 = Type:4#Index:7#LocalPosition:69.24,-3.045,4.385#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveS#PotentiometerIndex:85       ; MAIN PNL AMB S L
-lightdef.105 = Type:4#Index:7#LocalPosition:69.25,2.955,4.505#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85      ; MAIN PNL AMB M R
-lightdef.106 = Type:4#Index:7#LocalPosition:69.27,2.825,4.685#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85       ; MAIN PNL AMB M R
-lightdef.107 = Type:4#Index:7#LocalPosition:70.052,2.41,4.505#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85       ; MAIN PNL AMB M R
-lightdef.108 = Type:4#Index:7#LocalPosition:69.24,3.045,4.385#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveS#PotentiometerIndex:85        ; MAIN PNL AMB S R
-lightdef.109 = Type:4#Index:7#LocalPosition:69.93,-0.61,4.075#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveS#PotentiometerIndex:85        ; MAIN PNL AMB S CENTER L
-lightdef.110 = Type:4#Index:7#LocalPosition:70.014,0.6,4.385#LocalRotation:-163,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85   ; MAIN PNL AMB M CENTER R
+lightdef.101 = Type:4#Index:7#LocalPosition:69.25,-2.955,4.505#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85     ; MAIN PNL AMB M L
+lightdef.102 = Type:4#Index:7#LocalPosition:69.27,-2.825,4.685#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85      ; MAIN PNL AMB M L
+lightdef.103 = Type:4#Index:7#LocalPosition:70.052,-2.41,4.505#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85      ; MAIN PNL AMB M L
+lightdef.104 = Type:4#Index:7#LocalPosition:69.24,-3.045,4.385#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveS#PotentiometerIndex:85       ; MAIN PNL AMB S L
+lightdef.105 = Type:4#Index:7#LocalPosition:69.25,2.955,4.505#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85      ; MAIN PNL AMB M R
+lightdef.106 = Type:4#Index:7#LocalPosition:69.27,2.825,4.685#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85       ; MAIN PNL AMB M R
+lightdef.107 = Type:4#Index:7#LocalPosition:70.052,2.41,4.505#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85       ; MAIN PNL AMB M R
+lightdef.108 = Type:4#Index:7#LocalPosition:69.24,3.045,4.385#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveS#PotentiometerIndex:85        ; MAIN PNL AMB S R
+lightdef.109 = Type:4#Index:7#LocalPosition:69.93,-0.61,4.075#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveS#PotentiometerIndex:85        ; MAIN PNL AMB S CENTER L
+lightdef.110 = Type:4#Index:7#LocalPosition:70.014,0.6,4.385#LocalRotation:-163,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85   ; MAIN PNL AMB M CENTER R
 
 ; PEDESTAL INTEG LT AMBIENT (DONE)
-lightdef.111 = Type:4#Index:9#LocalPosition:69.53,0,3.195#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85               ; PED AMB CENTER
-lightdef.112 = Type:4#Index:9#LocalPosition:69.53,-0.3,3.195#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85            ; PED AMB M L
-lightdef.113 = Type:4#Index:9#LocalPosition:69.53,0.3,3.195#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85             ; PED AMB M R
-lightdef.114 = Type:4#Index:9#LocalPosition:69.43,-0.3,3.289#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85           ; PED AMB M L
-lightdef.115 = Type:4#Index:9#LocalPosition:69.29,-0.35,3.261#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85         ; PED AMB M L
-lightdef.116 = Type:4#Index:9#LocalPosition:69.1,-0.3,3.219#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveS#PotentiometerIndex:85          ; PED AMB S L
-lightdef.117 = Type:4#Index:9#LocalPosition:68.807,-0.672,3.151#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85       ; PED AMB M L
-lightdef.118 = Type:4#Index:9#LocalPosition:68.545,-0.672,3.094#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85   ; PED AMB M L
-lightdef.119 = Type:4#Index:9#LocalPosition:68.545,-0.5,3.094#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85         ; PED AMB M L
-lightdef.120 = Type:4#Index:9#LocalPosition:68.46,-0.42,3.085#LocalRotation:-104,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85         ; PED AMB M L
-lightdef.121 = Type:4#Index:9#LocalPosition:68.33,-0.73,3.045#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85       ; PED AMB M L
-lightdef.122 = Type:4#Index:9#LocalPosition:68.03,-0.73,2.963#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85        ; PED AMB M L
-lightdef.123 = Type:4#Index:9#LocalPosition:68.21,-0.5,3.001#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85          ; PED AMB M l
-lightdef.124 = Type:4#Index:9#LocalPosition:67.96,-0.73,2.947#LocalRotation:-100,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85     ; PED AMB M L
-lightdef.125 = Type:4#Index:9#LocalPosition:67.96,-0.88,2.947#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85     ; PED AMB M L
-lightdef.126 = Type:4#Index:9#LocalPosition:68.05,-0.48,2.947#LocalRotation:-98,0,0#EffectFile:LIGHT_A32NX_EmissiveS#PotentiometerIndex:85          ; PED AMB S L
-lightdef.127 = Type:4#Index:9#LocalPosition:67.59,-0.52,2.912#LocalRotation:-90,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85          ; PED AMB M MID
-lightdef.128 = Type:4#Index:9#LocalPosition:67.43,-0.46,2.912#LocalRotation:-90,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85       ; PED AMB M MID
-lightdef.129 = Type:4#Index:9#LocalPosition:67.59,0,2.914#LocalRotation:-90,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85              ; PED AMB M MID
-lightdef.130 = Type:4#Index:9#LocalPosition:67.59,0.12,2.914#LocalRotation:-90,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85           ; PED AMB M MID
-lightdef.131 = Type:4#Index:9#LocalPosition:67.28,-0.1,2.914#LocalRotation:-90,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85           ; PED AMB M MID
-lightdef.132 = Type:4#Index:9#LocalPosition:67.63,0.460,2.912#LocalRotation:-90,0,0#EffectFile:LIGHT_A32NX_EmissiveS#PotentiometerIndex:85           ; PED AMB S MID
-lightdef.133 = Type:4#Index:9#LocalPosition:68.06,0,2.972#LocalRotation:-103,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85         ; PED AMB M MID
-lightdef.134 = Type:4#Index:9#LocalPosition:68.06,-0.09,2.972#LocalRotation:-103,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85         ; PED AMB M MID
-lightdef.135 = Type:4#Index:9#LocalPosition:68.06,0.09,2.972#LocalRotation:-103,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85          ; PED AMB M MID
-lightdef.136 = Type:4#Index:9#LocalPosition:67.96,0.25,2.947#LocalRotation:-100,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85          ; PED AMB M R
-lightdef.137 = Type:4#Index:9#LocalPosition:67.96,0.64,2.947#LocalRotation:-100,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85      ; PED AMB M R
-lightdef.138 = Type:4#Index:9#LocalPosition:68.21,0.5,3.001#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85           ; PED AMB M R
-lightdef.139 = Type:4#Index:9#LocalPosition:68.545,0.672,3.094#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveHardM#PotentiometerIndex:85    ; PED AMB M R
-lightdef.140 = Type:4#Index:9#LocalPosition:68.807,0.672,3.151#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85        ; PED AMB M R
-lightdef.141 = Type:4#Index:9#LocalPosition:68.545,0.5,3.094#LocalRotation:-102,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85          ; PED AMB M R
-lightdef.142 = Type:4#Index:9#LocalPosition:68.46,0.42,3.085#LocalRotation:-104,0,0#EffectFile:LIGHT_A32NX_EmissiveM#PotentiometerIndex:85          ; PED AMB M R
+lightdef.111 = Type:4#Index:9#LocalPosition:69.53,0,3.195#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85               ; PED AMB CENTER
+lightdef.112 = Type:4#Index:9#LocalPosition:69.53,-0.3,3.195#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85            ; PED AMB M L
+lightdef.113 = Type:4#Index:9#LocalPosition:69.53,0.3,3.195#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85             ; PED AMB M R
+lightdef.114 = Type:4#Index:9#LocalPosition:69.43,-0.3,3.289#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85           ; PED AMB M L
+lightdef.115 = Type:4#Index:9#LocalPosition:69.29,-0.35,3.261#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85         ; PED AMB M L
+lightdef.116 = Type:4#Index:9#LocalPosition:69.1,-0.3,3.219#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveS#PotentiometerIndex:85          ; PED AMB S L
+lightdef.117 = Type:4#Index:9#LocalPosition:68.807,-0.672,3.151#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85       ; PED AMB M L
+lightdef.118 = Type:4#Index:9#LocalPosition:68.545,-0.672,3.094#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85   ; PED AMB M L
+lightdef.119 = Type:4#Index:9#LocalPosition:68.545,-0.5,3.094#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85         ; PED AMB M L
+lightdef.120 = Type:4#Index:9#LocalPosition:68.46,-0.42,3.085#LocalRotation:-104,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85         ; PED AMB M L
+lightdef.121 = Type:4#Index:9#LocalPosition:68.33,-0.73,3.045#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85       ; PED AMB M L
+lightdef.122 = Type:4#Index:9#LocalPosition:68.03,-0.73,2.963#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85        ; PED AMB M L
+lightdef.123 = Type:4#Index:9#LocalPosition:68.21,-0.5,3.001#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85          ; PED AMB M l
+lightdef.124 = Type:4#Index:9#LocalPosition:67.96,-0.73,2.947#LocalRotation:-100,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85     ; PED AMB M L
+lightdef.125 = Type:4#Index:9#LocalPosition:67.96,-0.88,2.947#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85     ; PED AMB M L
+lightdef.126 = Type:4#Index:9#LocalPosition:68.05,-0.48,2.947#LocalRotation:-98,0,0#EffectFile:LIGHT_A339_EmissiveS#PotentiometerIndex:85          ; PED AMB S L
+lightdef.127 = Type:4#Index:9#LocalPosition:67.59,-0.52,2.912#LocalRotation:-90,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85          ; PED AMB M MID
+lightdef.128 = Type:4#Index:9#LocalPosition:67.43,-0.46,2.912#LocalRotation:-90,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85       ; PED AMB M MID
+lightdef.129 = Type:4#Index:9#LocalPosition:67.59,0,2.914#LocalRotation:-90,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85              ; PED AMB M MID
+lightdef.130 = Type:4#Index:9#LocalPosition:67.59,0.12,2.914#LocalRotation:-90,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85           ; PED AMB M MID
+lightdef.131 = Type:4#Index:9#LocalPosition:67.28,-0.1,2.914#LocalRotation:-90,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85           ; PED AMB M MID
+lightdef.132 = Type:4#Index:9#LocalPosition:67.63,0.460,2.912#LocalRotation:-90,0,0#EffectFile:LIGHT_A339_EmissiveS#PotentiometerIndex:85           ; PED AMB S MID
+lightdef.133 = Type:4#Index:9#LocalPosition:68.06,0,2.972#LocalRotation:-103,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85         ; PED AMB M MID
+lightdef.134 = Type:4#Index:9#LocalPosition:68.06,-0.09,2.972#LocalRotation:-103,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85         ; PED AMB M MID
+lightdef.135 = Type:4#Index:9#LocalPosition:68.06,0.09,2.972#LocalRotation:-103,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85          ; PED AMB M MID
+lightdef.136 = Type:4#Index:9#LocalPosition:67.96,0.25,2.947#LocalRotation:-100,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85          ; PED AMB M R
+lightdef.137 = Type:4#Index:9#LocalPosition:67.96,0.64,2.947#LocalRotation:-100,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85      ; PED AMB M R
+lightdef.138 = Type:4#Index:9#LocalPosition:68.21,0.5,3.001#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85           ; PED AMB M R
+lightdef.139 = Type:4#Index:9#LocalPosition:68.545,0.672,3.094#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveHardM#PotentiometerIndex:85    ; PED AMB
+lightdef.140 = Type:4#Index:9#LocalPosition:68.807,0.672,3.151#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85        ; PED AMB M R
+lightdef.141 = Type:4#Index:9#LocalPosition:68.545,0.5,3.094#LocalRotation:-102,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85          ; PED AMB M R
+lightdef.142 = Type:4#Index:9#LocalPosition:68.46,0.42,3.085#LocalRotation:-104,0,0#EffectFile:LIGHT_A339_EmissiveM#PotentiometerIndex:85          ; PED AMB M R
 
 ; DOME LT (DONE)
-lightdef.143 = Type:10#Index:1#LocalPosition:65.83,-1.7,7.635#LocalRotation:70,0,0#EffectFile:LIGHT_A32NX_CockpitSpotLarge#PotentiometerIndex:7        ; DOME LT CPT
-lightdef.144 = Type:10#Index:1#LocalPosition:65.83,-1.0,2.635#LocalRotation:270,500,0#EffectFile:LIGHT_A32NX_CockpitSpotLarge#PotentiometerIndex:7     ; DOME LT CPT AMB
-lightdef.145 = Type:10#Index:2#LocalPosition:65.83,1.7,7.635#LocalRotation:70,0,0#EffectFile:LIGHT_A32NX_CockpitSpotLarge#PotentiometerIndex:7         ; DOME LT F/O
-lightdef.146 = Type:10#Index:2#LocalPosition:65.83,1.0,2.635#LocalRotation:270,500,0#EffectFile:LIGHT_A32NX_CockpitSpotLarge#PotentiometerIndex:7      ; DOME LT F/O AMB
+lightdef.143 = Type:10#Index:1#LocalPosition:65.83,-1.7,7.635#LocalRotation:70,0,0#EffectFile:LIGHT_A339_CockpitSpotLarge#PotentiometerIndex:7        ; DOME LT CPT
+lightdef.144 = Type:10#Index:1#LocalPosition:65.83,-1.0,2.635#LocalRotation:270,500,0#EffectFile:LIGHT_A339_CockpitSpotLarge#PotentiometerIndex:7     ; DOME LT CPT AMB
+lightdef.145 = Type:10#Index:2#LocalPosition:65.83,1.7,7.635#LocalRotation:70,0,0#EffectFile:LIGHT_A339_CockpitSpotLarge#PotentiometerIndex:7         ; DOME LT F/O
+lightdef.146 = Type:10#Index:2#LocalPosition:65.83,1.0,2.635#LocalRotation:270,500,0#EffectFile:LIGHT_A339_CockpitSpotLarge#PotentiometerIndex:7      ; DOME LT F/O AMB
 
 ; PEDESTAL FLOOD LT (DONE)
-lightdef.147 = Type:11#Index:1#LocalPosition:66.23,0,7.435#LocalRotation:80,0,0#EffectFile:LIGHT_A32NX_Pedestal#PotentiometerIndex:76          ; PEDESTAL FLOOD LT
-lightdef.148 = Type:11#Index:1#LocalPosition:67.03,0,5.535#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_PedestalAmbient#PotentiometerIndex:76      ; PEDESTAL FLOOD LT AMB
+lightdef.147 = Type:11#Index:1#LocalPosition:66.23,0,7.435#LocalRotation:80,0,0#EffectFile:LIGHT_A339_Pedestal#PotentiometerIndex:76          ; PEDESTAL FLOOD LT
+lightdef.148 = Type:11#Index:1#LocalPosition:67.03,0,5.535#LocalRotation:0,0,0#EffectFile:LIGHT_A339_PedestalAmbient#PotentiometerIndex:76      ; PEDESTAL FLOOD LT AMB
 
 ; MAIN PNL FLOOD LT (DONE)
-lightdef.149 = Type:12#Index:3#LocalPosition:70,-2.6,4.805#LocalRotation:-10,0,-30#EffectFile:LIGHT_A32NX_MainPanelFloodEnd#PotentiometerIndex:83     ; CPT L
-lightdef.150 = Type:12#Index:3#LocalPosition:70,-0.6,5.135#LocalRotation:-10,0,0#EffectFile:LIGHT_A32NX_MainPanelFloodCenter#PotentiometerIndex:83     ; CPT R
-lightdef.151 = Type:12#Index:4#LocalPosition:70,0.7,5.135#LocalRotation:-10,0,0#EffectFile:LIGHT_A32NX_MainPanelFloodCenter#PotentiometerIndex:83      ; F/O L
-lightdef.152 = Type:12#Index:4#LocalPosition:70,2.6,4.805#LocalRotation:-10,0,30#EffectFile:LIGHT_A32NX_MainPanelFloodEnd#PotentiometerIndex:83       ; F/O R
-lightdef.153 = Type:12#Index:3#LocalPosition:69.83,-2.58,4.715#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_MainPanelFloodAmbientEnd#PotentiometerIndex:83  ; CPT AMB
-lightdef.154 = Type:12#Index:3#LocalPosition:69.78,0,4.735#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_MainPanelFloodAmbientCenter#PotentiometerIndex:83   ; CENTER AMB
-lightdef.155 = Type:12#Index:4#LocalPosition:69.83,2.58,4.715#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_MainPanelFloodAmbientEnd#PotentiometerIndex:83   ; F/O AMB
+lightdef.149 = Type:12#Index:3#LocalPosition:70,-2.6,4.805#LocalRotation:-10,0,-30#EffectFile:LIGHT_A339_MainPanelFloodEnd#PotentiometerIndex:83     ; CPT L
+lightdef.150 = Type:12#Index:3#LocalPosition:70,-0.6,5.135#LocalRotation:-10,0,0#EffectFile:LIGHT_A339_MainPanelFloodCenter#PotentiometerIndex:83     ; CPT R
+lightdef.151 = Type:12#Index:4#LocalPosition:70,0.7,5.135#LocalRotation:-10,0,0#EffectFile:LIGHT_A339_MainPanelFloodCenter#PotentiometerIndex:83      ; F/O L
+lightdef.152 = Type:12#Index:4#LocalPosition:70,2.6,4.805#LocalRotation:-10,0,30#EffectFile:LIGHT_A339_MainPanelFloodEnd#PotentiometerIndex:83       ; F/O R
+lightdef.153 = Type:12#Index:3#LocalPosition:69.83,-2.58,4.715#LocalRotation:0,0,0#EffectFile:LIGHT_A339_MainPanelFloodAmbientEnd#PotentiometerIndex:83  ; CPT AMB
+lightdef.154 = Type:12#Index:3#LocalPosition:69.78,0,4.735#LocalRotation:0,0,0#EffectFile:LIGHT_A339_MainPanelFloodAmbientCenter#PotentiometerIndex:83   ; CENTER AMB
+lightdef.155 = Type:12#Index:4#LocalPosition:69.83,2.58,4.715#LocalRotation:0,0,0#EffectFile:LIGHT_A339_MainPanelFloodAmbientEnd#PotentiometerIndex:83   ; F/O AMB
 
 ; CPT / F/O TABLE LT (DONE)
-lightdef.156 = Type:12#Index:1#LocalPosition:69.53,-1.825,4.915#LocalRotation:104,0,90#EffectFile:LIGHT_A32NX_ScreenOrange#PotentiometerIndex:10  ; CPT TABLE LT
-lightdef.157 = Type:12#Index:2#LocalPosition:69.53,1.76,4.915#LocalRotation:104,0,90#EffectFile:LIGHT_A32NX_ScreenOrange#PotentiometerIndex:11    ; F/O TABLE LT
+lightdef.156 = Type:12#Index:1#LocalPosition:69.53,-1.825,4.915#LocalRotation:104,0,90#EffectFile:LIGHT_A339_ScreenOrange#PotentiometerIndex:10  ; CPT TABLE LT
+lightdef.157 = Type:12#Index:2#LocalPosition:69.53,1.76,4.915#LocalRotation:104,0,90#EffectFile:LIGHT_A339_ScreenOrange#PotentiometerIndex:11    ; F/O TABLE LT
 
 ; CTP / F/O CONSOLE/FLOOR LT (DONE)
-lightdef.158 = Type:4#Index:3#LocalPosition:68.03,-4,4.035#LocalRotation:90,0,0#EffectFile:LIGHT_A32NX_Console#PotentiometerIndex:8  ; CONSOLE/FLOOR LT CPT
-lightdef.159 = Type:4#Index:6#LocalPosition:68.03,4,4.035#LocalRotation:90,0,0#EffectFile:LIGHT_A32NX_Console#PotentiometerIndex:9   ; CONSOLE/FLOOR LT F/O
+lightdef.158 = Type:4#Index:3#LocalPosition:68.03,-4,4.035#LocalRotation:90,0,0#EffectFile:LIGHT_A339_Console#PotentiometerIndex:8  ; CONSOLE/FLOOR LT CPT
+lightdef.159 = Type:4#Index:6#LocalPosition:68.03,4,4.035#LocalRotation:90,0,0#EffectFile:LIGHT_A339_Console#PotentiometerIndex:9   ; CONSOLE/FLOOR LT F/O
 
 ; JUMPSEAT READING LT (DONE)
-lightdef.160 = Type:4#Index:5#LocalPosition:66.03,0.96,7.935#LocalRotation:110,90,0#EffectFile:LIGHT_A32NX_CockpitSpotNarrow#PotentiometerIndex:97             ; READING LT R
-lightdef.161 = Type:4#Index:5#LocalPosition:65.518,-1.16,7.975#LocalRotation:110,90,0#EffectFile:LIGHT_A32NX_CockpitSpotNarrow#PotentiometerIndex:96     ; READING LT L
+lightdef.160 = Type:4#Index:5#LocalPosition:66.03,0.96,7.935#LocalRotation:110,90,0#EffectFile:LIGHT_A339_CockpitSpotNarrow#PotentiometerIndex:97             ; READING LT R
+lightdef.161 = Type:4#Index:5#LocalPosition:65.518,-1.16,7.975#LocalRotation:110,90,0#EffectFile:LIGHT_A339_CockpitSpotNarrow#PotentiometerIndex:96     ; READING LT L
 
 ; C&D AMBIENT (DONE)
-lightdef.162 = Type:13#Index:0#LocalPosition:67.53,0,4.935#LocalRotation:0,0,0#EffectFile:LIGHT_A32NX_AmbientColdDark#PotentiometerIndex:1   ; COLD & DARK AMBIENT
+lightdef.162 = Type:13#Index:0#LocalPosition:67.53,0,4.935#LocalRotation:0,0,0#EffectFile:LIGHT_A339_AmbientColdDark#PotentiometerIndex:1   ; COLD & DARK AMBIENT
 
 
 [BRAKES]


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page